### PR TITLE
Migration to PyQt5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     ],
     packages=find_packages(),
     install_requires=[
-        'simso>=0.8',
+        'simso>=0.9',
     ],
     entry_points={
         'gui_scripts': ['simso = simsogui:run_gui']

--- a/simsogui/Configuration.py
+++ b/simsogui/Configuration.py
@@ -1,4 +1,4 @@
-from PyQt4.QtCore import QObject, pyqtSignal
+from PyQt5.QtCore import QObject, pyqtSignal
 
 import simso.configuration as conf
 

--- a/simsogui/Gantt.py
+++ b/simsogui/Gantt.py
@@ -1,8 +1,6 @@
-from PyQt4.QtCore import Qt, QRect, QRectF, QLineF, QPointF
-from PyQt4.QtGui import QDialog, QVBoxLayout, QListWidget, QToolBar, QWidget, \
-    QHBoxLayout, QPushButton, qApp, QStyle, QSizePolicy, QBrush,\
-    QScrollArea, QFileDialog, QPainter, QColor, QPen, QFont,\
-    QImage, QListWidgetItem
+from PyQt5.QtCore import Qt, QRect, QRectF, QLineF, QPointF
+from PyQt5.QtGui import QPen, QFont, QImage, QPainter, QColor, QBrush
+from PyQt5.QtWidgets import QApplication, QDialog, QFileDialog, QHBoxLayout, QListWidgetItem, QListWidget, QPushButton, QScrollArea, QSizePolicy, QStyle, QToolBar, QVBoxLayout, QWidget
 
 from .QxtSpanSlider import QxtSpanSliderWidget
 
@@ -63,7 +61,7 @@ class GanttConfigure(QDialog):
         for row in range(0, self._list_elements.count()):
             if self._list_elements.item(row).checkState() == Qt.Checked:
                 try:
-                    data = self._list_elements.item(row).data(Qt.UserRole).toPyObject()
+                    data = self._list_elements.item(row).data(Qt.UserRole)
                 except AttributeError:
                     data = self._list_elements.item(row).data(Qt.UserRole)
 
@@ -332,7 +330,7 @@ class GanttCanvas(QWidget):
     def saveImg(self):
         imageFile = QFileDialog.getSaveFileName(
             filter="*.png",
-            caption="Image file name")
+            caption="Image file name")[0]
         if imageFile:
             if str(imageFile[-4:]) != ".png":
                 imageFile += ".png"
@@ -392,7 +390,7 @@ class GanttToolBar(QToolBar):
     def __init__(self, parent, canvas):
         QToolBar.__init__(self, parent)
         self._canvas = canvas
-        self.addAction(qApp.style().standardIcon(QStyle.SP_DialogSaveButton),
+        self.addAction(QApplication.style().standardIcon(QStyle.SP_DialogSaveButton),
                        "Save", canvas.saveImg)
         self.addAction("Zoom +", canvas.zoomUp)
         self.addAction("Zoom -", canvas.zoomDown)

--- a/simsogui/ModelWindow/AddRemoveButtonBar.py
+++ b/simsogui/ModelWindow/AddRemoveButtonBar.py
@@ -1,5 +1,4 @@
-from PyQt4.QtGui import QWidget, QHBoxLayout, QPushButton, QSpacerItem, \
-    QSizePolicy, QStyle, qApp
+from PyQt5.QtWidgets import QApplication, QHBoxLayout, QPushButton, QSizePolicy, QSpacerItem, QStyle, QWidget
 
 
 class AddRemoveButtonBar(QWidget):
@@ -8,7 +7,7 @@ class AddRemoveButtonBar(QWidget):
         QWidget.__init__(self, parent)
         layout = QHBoxLayout()
         remove_button = QPushButton(remove_text, self)
-        remove_button.setIcon(qApp.style().standardIcon(QStyle.SP_TrashIcon))
+        remove_button.setIcon(QApplication.style().standardIcon(QStyle.SP_TrashIcon))
         remove_button.clicked.connect(remove_method)
         layout.addWidget(remove_button)
         layout.setContentsMargins(8, 0, 8, 0)

--- a/simsogui/ModelWindow/CachesTab.py
+++ b/simsogui/ModelWindow/CachesTab.py
@@ -2,11 +2,9 @@
 # coding=utf-8
 
 import re
+from PyQt5.QtWidgets import QAbstractItemView, QHeaderView, QMessageBox, QTableWidgetItem, QTableWidget
 
-from PyQt4.QtCore import Qt
-from PyQt4.QtGui import QTableWidget, QTableWidgetItem, QHeaderView, \
-    QAbstractItemView, QMessageBox
-
+from PyQt5.QtCore import Qt
 from .AddRemoveButtonBar import AddRemoveButtonBar
 from .Tab import Tab
 from simso.core.Caches import Cache_LRU
@@ -38,7 +36,7 @@ class CachesTable(QTableWidget):
         self._caches_list = configuration.caches_list
         QTableWidget.__init__(self, len(self._caches_list), 5, parent)
         self.horizontalHeader().setStretchLastSection(True)
-        self.horizontalHeader().setResizeMode(QHeaderView.ResizeToContents)
+        self.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
         self.setHorizontalHeaderLabels(["id", "Name", "Size", 'Access Time',
                                         "Miss penalty"])
         self.setVerticalHeaderLabels([""])

--- a/simsogui/ModelWindow/CustomFieldsEditor.py
+++ b/simsogui/ModelWindow/CustomFieldsEditor.py
@@ -1,5 +1,4 @@
-from PyQt4.QtGui import QDialog, QVBoxLayout, QWidget, QHBoxLayout, QLabel, \
-    QLineEdit, QComboBox, QPushButton, QListWidget, QAbstractItemView
+from PyQt5.QtWidgets import QAbstractItemView, QComboBox, QDialog, QHBoxLayout, QLabel, QLineEdit, QListWidget, QPushButton, QVBoxLayout, QWidget
 from .AddRemoveButtonBar import AddRemoveButtonBar
 import re
 

--- a/simsogui/ModelWindow/GeneralTab.py
+++ b/simsogui/ModelWindow/GeneralTab.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-from PyQt4.QtGui import QTableWidget, QTableWidgetItem, QComboBox
+from PyQt5.QtWidgets import QComboBox, QTableWidgetItem, QTableWidget
 
 from .Tab import Tab
 from simso.core.etm import execution_time_model_names

--- a/simsogui/ModelWindow/ModelWindow.py
+++ b/simsogui/ModelWindow/ModelWindow.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # coding=utf-8
 
-from PyQt4.QtGui import QTabWidget, QStyle, QIcon
+from PyQt5.QtGui import QIcon
+from PyQt5.QtWidgets import QStyle, QTabWidget
 
 from .GeneralTab import GeneralTab
 from .SchedulerTab import SchedulerTab

--- a/simsogui/ModelWindow/ProcessorsTab.py
+++ b/simsogui/ModelWindow/ProcessorsTab.py
@@ -1,8 +1,7 @@
 import re
-
-from PyQt4.QtCore import Qt
-from PyQt4.QtGui import QTableWidget, QTableWidgetItem, QHeaderView, \
-    QAbstractItemView, QWidget, QHBoxLayout, QPushButton, QColor
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QAbstractItemView, QHBoxLayout, QHeaderView, QPushButton, QTableWidgetItem, QTableWidget, QWidget
+from PyQt5.QtGui import QColor
 
 from .AddRemoveButtonBar import AddRemoveButtonBar
 from .Tab import Tab
@@ -72,7 +71,7 @@ class ProcessorsTable(QTableWidget):
                               parent)
         self._configuration = configuration
         self._manual_change = True
-        self.horizontalHeader().setResizeMode(QHeaderView.ResizeToContents)
+        self.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
         self.horizontalHeader().setStretchLastSection(True)
         self._header = ['id', 'Name', 'CS overhead', 'CL overhead', 'Caches',
                         'Cycles / mem access', 'Speed']

--- a/simsogui/ModelWindow/SchedulerTab.py
+++ b/simsogui/ModelWindow/SchedulerTab.py
@@ -1,9 +1,8 @@
 # coding=utf-8
 
 import os
-from PyQt4.QtCore import Qt
-from PyQt4.QtGui import QTableWidget, QTableWidgetItem, QFileDialog, \
-    QPushButton, QHeaderView, QWidget, QHBoxLayout, QComboBox
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QComboBox, QFileDialog, QHBoxLayout, QHeaderView, QPushButton, QTableWidgetItem, QTableWidget, QWidget
 
 from .CustomFieldsEditor import CustomFieldsEditor
 from .Tab import Tab
@@ -105,9 +104,9 @@ class SchedulerTable(QTableWidget):
         self.setVerticalHeaderLabels(labels)
         self.horizontalHeader().setStretchLastSection(False)
         header = self.horizontalHeader()
-        header.setResizeMode(0, QHeaderView.Stretch)
-        header.setResizeMode(1, QHeaderView.Interactive)
-        #header.setResizeMode(2, QHeaderView.Interactive)
+        header.setSectionResizeMode(0, QHeaderView.Stretch)
+        header.setSectionResizeMode(1, QHeaderView.Interactive)
+        #header.setSectionResizeMode(2, QHeaderView.Interactive)
         self.horizontalHeader().hide()
 
         combo = QComboBox()
@@ -186,7 +185,7 @@ class SchedulerTable(QTableWidget):
         name = QFileDialog.getOpenFileName(
             self, caption="Open scheduler",
             directory=self._configuration.scheduler_info.filename,
-            filter="*.py")
+            filter="*.py")[0]
         try:
             name = unicode(name)
         except NameError:

--- a/simsogui/ModelWindow/Tab.py
+++ b/simsogui/ModelWindow/Tab.py
@@ -1,5 +1,4 @@
-from PyQt4.QtGui import QWidget, QStatusBar, QVBoxLayout
-
+from PyQt5.QtWidgets import QStatusBar, QVBoxLayout, QWidget
 
 class Tab(QWidget):
     def __init__(self, parent, configuration):

--- a/simsogui/ModelWindow/TasksTab.py
+++ b/simsogui/ModelWindow/TasksTab.py
@@ -2,11 +2,9 @@
 # coding=utf-8
 
 import re
-
-from PyQt4.QtCore import Qt
-from PyQt4.QtGui import QTableWidget, QTableWidgetItem, QHeaderView, \
-    QAbstractItemView, QFileDialog, QColor, QWidget, QPushButton, \
-    QHBoxLayout, QComboBox
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QAbstractItemView, QComboBox, QFileDialog, QHBoxLayout, QHeaderView, QPushButton, QTableWidgetItem, QTableWidget, QWidget
+from PyQt5.QtGui import QColor
 
 from .Tab import Tab
 from .AddRemoveButtonBar import AddRemoveButtonBar
@@ -99,7 +97,7 @@ class TasksTable(QTableWidget):
     def __init__(self, parent, configuration):
         QTableWidget.__init__(self, 0, 0, parent)
         self._ignore_cell_changed = False
-        self.horizontalHeader().setResizeMode(QHeaderView.Interactive)
+        self.horizontalHeader().setSectionResizeMode(QHeaderView.Interactive)
         self.horizontalHeader().setStretchLastSection(True)
         self.verticalHeader().hide()
         self._configuration = configuration
@@ -246,7 +244,7 @@ class TasksTable(QTableWidget):
 
     def _cell_activated(self, row, col):
         if col == self._dict_header['sdp']:
-            name = QFileDialog.getOpenFileName(self, caption="Open stack file")
+            name = QFileDialog.getOpenFileName(self, caption="Open stack file")[0]
             if name:
                 task = self._configuration.task_info_list[row]
                 task.set_stack_file(str(name), self._configuration.cur_dir)

--- a/simsogui/QCopyTableWidget.py
+++ b/simsogui/QCopyTableWidget.py
@@ -1,5 +1,5 @@
-from PyQt4.QtCore import Qt, QByteArray, QMimeData
-from PyQt4.QtGui import QTableWidget, QApplication
+from PyQt5.QtCore import Qt, QByteArray, QMimeData
+from PyQt5.QtWidgets import QApplication, QTableWidget
 
 
 class QCopyTableWidget(QTableWidget):

--- a/simsogui/SimulatorWindow.py
+++ b/simsogui/SimulatorWindow.py
@@ -1,10 +1,9 @@
 #!/usr/bin/python
 # coding=utf-8
 
-from PyQt4.QtWebKit import QWebView
-from PyQt4.QtCore import Qt, QUrl, QSettings, QFileInfo
-from PyQt4.QtGui import QMainWindow, QMenu, QAction, QStyle, \
-    QToolBar, QFileDialog, qApp, QTabWidget, QDockWidget, QMessageBox
+from PyQt5.QtWebEngineWidgets import QWebEngineView as QWebView
+from PyQt5.QtCore import Qt, QUrl, QSettings, QFileInfo
+from PyQt5.QtWidgets import QAction, QApplication, QDockWidget, QFileDialog, QMainWindow, QMenu, QMessageBox, QStyle, QTabWidget, QToolBar
 
 import os.path
 import simso
@@ -20,7 +19,7 @@ class SimulatorWindow(QMainWindow):
         self.setWindowTitle("SimSo: Real-Time Scheduling Simulator")
 
         # Possible actions:
-        style = qApp.style()
+        style = QApplication.style()
 
         # New
         self._newAction = QAction(
@@ -224,7 +223,7 @@ class SimulatorWindow(QMainWindow):
 
     def fileOpen(self):
         simulation_file = QFileDialog.getOpenFileName(
-            filter="*.xml", caption="Open XML simulation file.")
+            filter="*.xml", caption="Open XML simulation file.")[0]
         if simulation_file:
             self.open_file(simulation_file)
 
@@ -259,7 +258,7 @@ class SimulatorWindow(QMainWindow):
 
     def fileSaveAs(self):
         simulation_file = QFileDialog.getSaveFileName(
-            filter="*.xml", caption="Save XML simulation file.")
+            filter="*.xml", caption="Save XML simulation file.")[0]
         try:
             simulation_file = unicode(simulation_file)
         except NameError:

--- a/simsogui/TaskGenerator.py
+++ b/simsogui/TaskGenerator.py
@@ -1,9 +1,7 @@
-from PyQt4.QtGui import QDialog, QSlider, QVBoxLayout, QHBoxLayout, \
-    QDoubleSpinBox, QSpinBox, QRadioButton, QWidget, QLineEdit, \
-    QRegExpValidator, QDialogButtonBox, QMessageBox, QGroupBox, QCheckBox, \
-    QComboBox, QLabel
-from PyQt4.QtCore import pyqtSignal, QRegExp
-from PyQt4 import QtCore
+from PyQt5.QtGui import QRegExpValidator
+from PyQt5.QtWidgets import QCheckBox, QComboBox, QDialogButtonBox, QDialog, QDoubleSpinBox, QGroupBox, QHBoxLayout, QLabel, QLineEdit, QMessageBox, QRadioButton, QSlider, QSpinBox, QVBoxLayout, QWidget
+from PyQt5.QtCore import pyqtSignal, QRegExp
+from PyQt5 import QtCore, QtWidgets
 from simso.generator.task_generator import StaffordRandFixedSum, \
     gen_periods_loguniform, gen_periods_uniform, gen_periods_discrete, \
     gen_tasksets, UUniFastDiscard, gen_kato_utilizations
@@ -224,11 +222,17 @@ class TaskGeneratorDialog(QDialog):
         return self.interval_utilization.getMax()
 
     def generate(self):
+
+        n = self.get_nb_tasks()
+        if (n == 0):
+            QMessageBox.warning(
+                    self, "Generation failed",
+                    "Please check the utilization and the number of tasks.")
+            return
+
         if self.comboGenerator.currentIndex() == 0:
-            n = self.get_nb_tasks()
             u = StaffordRandFixedSum(n, self.get_utilization(), 1)
         elif self.comboGenerator.currentIndex() == 1:
-            n = self.get_nb_tasks()
             u = UUniFastDiscard(n, self.get_utilization(), 1)
         else:
             u = gen_kato_utilizations(1, self.get_min_utilization(),
@@ -244,6 +248,7 @@ class TaskGeneratorDialog(QDialog):
                                        p_types[3])
         else:
             p = gen_periods_discrete(n, 1, p_types[1])
+            
         if u and p:
             self.taskset = gen_tasksets(u, p)[0]
             self.accept()
@@ -281,9 +286,8 @@ class TaskGeneratorDialog(QDialog):
 
 
 if __name__ == "__main__":
-    from PyQt4 import QtGui
     import sys
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     ex = TaskGeneratorDialog(5)
     if ex.exec_():
         print(ex.taskset)

--- a/simsogui/__init__.py
+++ b/simsogui/__init__.py
@@ -8,7 +8,7 @@ def run_gui():
     """
     import sys
     import optparse
-    from PyQt4.QtGui import QApplication
+    from PyQt5.QtWidgets import QApplication
     from simsogui.SimulatorWindow import SimulatorWindow
 
     parser = optparse.OptionParser()

--- a/simsogui/results/LoadTab.py
+++ b/simsogui/results/LoadTab.py
@@ -1,4 +1,5 @@
-from PyQt4.QtGui import QTableWidget, QTableWidgetItem, QAbstractItemView
+from PyQt5.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView
+#from PyQt5.QtWidgets import *
 from ..QCopyTableWidget import QCopyTableWidget
 
 
@@ -20,7 +21,7 @@ class LoadTable(QCopyTableWidget):
         sum_overhead = 0.0
 
         curRow = 0
-        for proc, load, overhead in self.result.calc_load():
+        for _, load, overhead in self.result.calc_load():
             self.setItem(curRow, 0,
                          QTableWidgetItem("%.4f" % (load + overhead)))
             self.setItem(curRow, 1, QTableWidgetItem("%.4f" % (load)))

--- a/simsogui/results/Logs.py
+++ b/simsogui/results/Logs.py
@@ -1,15 +1,15 @@
 #!/usr/bin/python
 # coding=utf-8
 
-from PyQt4.QtGui import QTableWidgetItem, QTableWidget, QHeaderView, QColor
-
+from PyQt5.QtGui import QColor
+from PyQt5.QtWidgets import QHeaderView, QTableWidgetItem, QTableWidget
 
 class Logs(QTableWidget):
     def __init__(self, parent, result):
         QTableWidget.__init__(self, len(result.model.logs), 3, parent=parent)
         self.setWindowTitle("Logs")
         self.setHorizontalHeaderLabels(["Date (cycles)", "Date (ms)", "Message"])
-        self.horizontalHeader().setResizeMode(QHeaderView.ResizeToContents)
+        self.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
         self.horizontalHeader().setStretchLastSection(True)
         self.horizontalHeader().setMinimumSectionSize(60)
         self.verticalHeader().hide()
@@ -28,12 +28,18 @@ class Logs(QTableWidget):
             self.setItem(row, 1, QTableWidgetItem(str(float(msg[0]) / self._sim.cycles_per_ms)))
             self.setItem(row, 2, QTableWidgetItem(str(msg[1][0])))
             if msg[1][1]:
-                self.item(row, 0).setBackgroundColor(QColor(180, 220, 255))
-                self.item(row, 1).setBackgroundColor(QColor(180, 220, 255))
-                self.item(row, 2).setBackgroundColor(QColor(180, 220, 255))
+                self.item(row, 0).setBackground(QColor(180, 220, 255))
+                self.item(row, 1).setBackground(QColor(180, 220, 255))
+                self.item(row, 2).setBackground(QColor(180, 220, 255))
+                #self.item(row, 0).setBackgroundColor(QColor(180, 220, 255))
+                #self.item(row, 1).setBackgroundColor(QColor(180, 220, 255))
+                #self.item(row, 2).setBackgroundColor(QColor(180, 220, 255))
             else:
-                self.item(row, 0).setBackgroundColor(QColor(220, 255, 180))
-                self.item(row, 1).setBackgroundColor(QColor(220, 255, 180))
-                self.item(row, 2).setBackgroundColor(QColor(220, 255, 180))
+                self.item(row, 0).setBackground(QColor(220, 255, 180))
+                self.item(row, 1).setBackground(QColor(220, 255, 180))
+                self.item(row, 2).setBackground(QColor(220, 255, 180))
+                #self.item(row, 0).setBackgroundColor(QColor(220, 255, 180))
+                #self.item(row, 1).setBackgroundColor(QColor(220, 255, 180))
+                #self.item(row, 2).setBackgroundColor(QColor(220, 255, 180))
             row += 1
         self.setRowCount(row)

--- a/simsogui/results/MetricsWindow.py
+++ b/simsogui/results/MetricsWindow.py
@@ -1,5 +1,4 @@
-from PyQt4.QtGui import QTabWidget, QVBoxLayout, QDialog, QButtonGroup, \
-    QRadioButton, QPushButton, QWidget, QHBoxLayout, QLabel, QGroupBox
+from PyQt5.QtWidgets import QButtonGroup, QDialog, QGroupBox, QHBoxLayout, QLabel, QPushButton, QRadioButton, QTabWidget, QVBoxLayout, QWidget
 from ..QxtSpanSlider import QxtSpanSliderWidget
 from .LoadTab import LoadTable
 from .TasksTab import TasksTab

--- a/simsogui/results/ProcessorsTab.py
+++ b/simsogui/results/ProcessorsTab.py
@@ -1,6 +1,4 @@
-from PyQt4.QtGui import QTabWidget, QLabel, QVBoxLayout, QGroupBox, \
-    QScrollArea, QWidget
-
+from PyQt5.QtWidgets import QGroupBox, QLabel, QScrollArea, QTabWidget, QVBoxLayout, QWidget
 
 class ProcessorsTab(QTabWidget):
     def __init__(self, result):
@@ -11,7 +9,7 @@ class ProcessorsTab(QTabWidget):
         self.update()
 
     def update(self):
-        for i in range(self.layout().count()):
+        for _ in range(self.layout().count()):
             self.layout().itemAt(0).widget().close()
             self.layout().takeAt(0)
 

--- a/simsogui/results/SchedulerTab.py
+++ b/simsogui/results/SchedulerTab.py
@@ -1,6 +1,4 @@
-from PyQt4.QtGui import QTabWidget, QLabel, QVBoxLayout, QGroupBox, QWidget, \
-    QScrollArea
-
+from PyQt5.QtWidgets import QGroupBox, QLabel, QScrollArea, QTabWidget, QVBoxLayout, QWidget
 
 class SchedulerTab(QTabWidget):
     def __init__(self, result):
@@ -10,7 +8,7 @@ class SchedulerTab(QTabWidget):
         self.update()
 
     def update(self):
-        for i in range(self.layout().count()):
+        for _ in range(self.layout().count()):
             self.layout().itemAt(0).widget().close()
             self.layout().takeAt(0)
 

--- a/simsogui/results/TasksTab.py
+++ b/simsogui/results/TasksTab.py
@@ -1,7 +1,6 @@
 # coding=utf-8
-
-from PyQt4.QtGui import QTabWidget, QTableWidget, QTableWidgetItem, QWidget,\
-    QVBoxLayout, QScrollArea, QAbstractItemView, QToolBox, QColor
+from PyQt5.QtWidgets import QAbstractItemView, QScrollArea, QTableWidgetItem, QTableWidget, QTabWidget, QToolBox, QVBoxLayout, QWidget
+from PyQt5.QtGui import QColor
 import numpy
 from ..QCopyTableWidget import QCopyTableWidget
 
@@ -40,7 +39,7 @@ class JobsList(QCopyTableWidget):
                 end_date = float(job.end_date) / cycles_per_ms
                 self.setItem(curRow, 2, QTableWidgetItem("%.4f" % end_date))
                 if job.exceeded_deadline:
-                    self.item(curRow, 2).setBackgroundColor(
+                    self.item(curRow, 2).setBackground(
                         QColor(220, 180, 180))
 
             self.setItem(curRow, 3,


### PR DESCRIPTION
. Implements all code changes required to migrate  to PyQt5
. Requires **python-pyqt5.qtwebengine** (SimulatorWindow uses QtWebEngineWidgets)
. Fixes some minor issues as reported by pylint
. Bumps version to 0.9