### PR TITLE
Pyqt5 upgrade minor corrections

### DIFF
--- a/simsogui/Gantt.py
+++ b/simsogui/Gantt.py
@@ -111,13 +111,13 @@ class GanttCanvas(QWidget):
                 text = str(i)
                 fw = qp.fontMetrics().width(text)
                 fh = qp.fontMetrics().height()
-                qp.drawText(x + convX(i - start_date) - fw // 2,
+                qp.drawText(int(x + convX(i - start_date) - fw // 2),
                             graph_height + y + fh + 1, text)
                 pen = qp.pen()
                 if i != start_date and i != end_date:
                     qp.setPen(QPen(Qt.DotLine))
-                    qp.drawLine(x + convX(i - start_date), y,
-                                x + convX(i - start_date),
+                    qp.drawLine(int(x + convX(i - start_date)), y,
+                                int(x + convX(i - start_date)),
                                 graph_height + y + 1)
                     qp.setPen(pen)
 
@@ -126,8 +126,8 @@ class GanttCanvas(QWidget):
                 h = 2
             if h:
                 qp.drawLine(
-                    x + convX(i - start_date), graph_height + 1 + y,
-                    x + convX(i - start_date), graph_height + y + 1 + h)
+                    int(x + convX(i - start_date)), graph_height + 1 + y,
+                    int(x + convX(i - start_date)), graph_height + y + 1 + h)
 
         qp.translate(x - 20, y + 65)
         qp.rotate(-90)
@@ -193,7 +193,7 @@ class GanttCanvas(QWidget):
         qp.setPen(color)
         qp.setBrush(color)
         x, y = self.origGraph(c)
-        qp.drawEllipse(x + self.convX(x_circle) - 1, y + 50 - 1, 3, 3)
+        qp.drawEllipse(int(x + self.convX(x_circle) - 1), y + 50 - 1, 3, 3)
         qp.restore()
 
     def get_color(self, i):
@@ -333,14 +333,14 @@ class GanttCanvas(QWidget):
             self._image[0].save(str(imageFile))
 
     def zoomDown(self):
-        self._vwidth /= 1.2
+        self._vwidth = int(self._vwidth / 1.2)
         if self._vwidth < 200:
             self._vwidth = 200
         self._width = self._vwidth + 40
         self._update()
 
     def zoomUp(self):
-        self._vwidth *= 1.2
+        self._vwidth = 	int(self._vwidth * 1.2)
         self._width = self._vwidth + 40
         self._update()
 

--- a/simsogui/ModelWindow/ProcessorsTab.py
+++ b/simsogui/ModelWindow/ProcessorsTab.py
@@ -142,7 +142,7 @@ class ProcessorsTable(QTableWidget):
                 item = QTableWidgetItem(str(proc_info.data[key]))
             else:
                 item = QTableWidgetItem('')
-            item.setBackgroundColor(QColor.fromRgb(200, 255, 200))
+            item.setBackground(QColor.fromRgb(200, 255, 200))
             self.setItem(row, col + len(self._header), item)
 
     def _cell_changed(self, row, col):

--- a/simsogui/ModelWindow/TasksTab.py
+++ b/simsogui/ModelWindow/TasksTab.py
@@ -228,7 +228,7 @@ class TasksTable(QTableWidget):
                 item = QTableWidgetItem(str(task.data[key]))
             else:
                 item = QTableWidgetItem('')
-            item.setBackgroundColor(QColor.fromRgb(200, 255, 200))
+            item.setBackground(QColor.fromRgb(200, 255, 200))
             self.setItem(row, col + len(self._header), item)
 
         self._ignore_cell_changed = False

--- a/simsogui/TaskGenerator.py
+++ b/simsogui/TaskGenerator.py
@@ -23,7 +23,7 @@ class _DoubleSlider(QSlider):
         QSlider.setMaximum(self, val * 100)
 
     def setValue(self, val):
-        QSlider.setValue(self, val * 100)
+        QSlider.setValue(self, int(val * 100))
 
 
 class IntervalSpinner(QWidget):


### PR DESCRIPTION
Since the migration to PyQt5, there were still a few obsolete methods to be replaced in the code (`setBackGroundColor`) leading to crashes. I also had to convert some float parameters to integers for some calls, as to the `drawText` and `drawEllipse` methods. The code was tested with the following versions:

- Python			3.11.6 
- PyQt5				5.15.10
- PyQtWebEngine	5.15.6
- simso				latest github version